### PR TITLE
Fix Kiro IDE integration descriptions in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ After running cc-sdd, you'll have:
 
 Brings to Claude Code, Cursor IDE and Gemini CLI your project context, Project Memory (steering) and development patterns: **requirements → design → tasks → implementation**. **Kiro IDE compatible** — Reuse Kiro-style SDD specs and workflows seamlessly.
 
-【Claude Code/Cursor IDE/Gemini CLI】ワンライナーで **AI-DLC（AI-Driven Development Life Cycle）** と **Spec-Driven Development（仕様駆動開発）** のワークフローを導入。プロジェクト直下に **10個のSlash Commands** 一式と設定ファイル（Claude Code用の **CLAUDE.md** / Cursor IDE用の **AGENTS.md** / Gemini CLI用の **GEMINI.md**）を配置し、プロジェクトの文脈と開発パターン（**要件 → 設計 → タスク → 実装**）、**プロジェクトメモリ（ステアリング）** を含みます。
+**【Claude Code/Cursor IDE/Gemini CLI】**
+ワンライナーで **AI-DLC（AI-Driven Development Life Cycle）** と **Spec-Driven Development（仕様駆動開発）** のワークフローを導入。プロジェクト直下に **10個のSlash Commands** 一式と設定ファイル（Claude Code用の **CLAUDE.md** / Cursor IDE用の **AGENTS.md** / Gemini CLI用の **GEMINI.md**）を配置、プロジェクトの文脈と開発パターン（**要件 → 設計 → タスク → 実装**）、**プロジェクトメモリ（ステアリング）** を含む。
 
 📝 **関連記事**  
 **[Kiroの仕様書駆動開発プロセスをClaude Codeで徹底的に再現した](https://zenn.dev/gotalab/articles/3db0621ce3d6d2)** - Zenn記事

--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@ npx cc-sdd@latest --cursor
 # Ready to go! Now Claude Code and Gemini CLI can leverage `/kiro:spec-init <what to build>` and the full SDD workflow
 ```
 
+## ✨ What You Get
+
+After running cc-sdd, you'll have:
+
+- **10 powerful slash commands** (`/kiro:steering`, `/kiro:spec-requirements`, `/kiro:validate-gap`, etc.)
+- **Project Memory (steering)** - AI learns your codebase, patterns, and preferences
+- **Structured AI-DLC workflow** with quality gates and approvals
+- **Spec-Driven Development** methodology built-in
+- **Kiro IDE compatibility** for seamless spec management
+
+**Perfect for**: Feature development, code reviews, technical planning, and maintaining development standards across your team.
+
 ## 🌐 Supported Languages
 
 - English (`en`)
@@ -46,17 +58,6 @@ npx cc-sdd@latest --cursor
 - Korean (`ko`)
 - Arabic (`ar`)
 
-## ✨ What You Get
-
-After running cc-sdd, you'll have:
-
-- **10 powerful slash commands** (`/kiro:steering`, `/kiro:spec-requirements`, `/kiro:validate-gap`, etc.)
-- **Project Memory (steering)** - AI learns your codebase, patterns, and preferences
-- **Structured AI-DLC workflow** with quality gates and approvals
-- **Spec-Driven Development** methodology built-in
-- **Kiro IDE compatibility** for seamless spec management
-
-**Perfect for**: Feature development, code reviews, technical planning, and maintaining development standards across your team.
 
 ---
 

--- a/tools/cc-sdd/README.md
+++ b/tools/cc-sdd/README.md
@@ -111,7 +111,7 @@ npx cc-sdd@latest --cursor --lang ja # For Cursor IDE instead
 
 > **Specifications as the Foundation**: Based on [Kiro's specs](https://kiro.dev/docs/specs/) - specs transform ad-hoc development into systematic workflows, bridging ideas to implementation with clear AI-human collaboration points.
 
-> **Kiro IDE Integration**: Specs are portable to [Kiro IDE](https://kiro.dev) - run `/kiro:spec-impl` with implementation guardrails and team collaboration features.
+> **Kiro IDE Integration**: Specs are portable to [Kiro IDE](https://kiro.dev) for enhanced implementation with guardrails and team collaboration features.
 
 ### Quality Validation (Optional - Brownfield Development)
 ```bash

--- a/tools/cc-sdd/README_ja.md
+++ b/tools/cc-sdd/README_ja.md
@@ -96,7 +96,7 @@ npx cc-sdd@latest --cursor --lang ja # Cursor IDE用
 
 > **仕様を基盤として**: [Kiroの仕様駆動手法](https://kiro.dev/docs/specs/)に基づく - 仕様がアドホック開発を体系的ワークフローに変換し、明確なAI-人間協働ポイントでアイデアから実装への橋渡しをします。
 
-> **Kiro IDE統合**: 作成された仕様はKiro IDEにポータブル - `/kiro:spec-impl`を実装ガードレールとチーム協働機能付きで実行できます。
+> **Kiro IDE統合**: 作成された仕様は[Kiro IDE](https://kiro.dev)での利用/実装も可能 - 強化された実装ガードレールとチーム協働機能を利用可能。
 
 ### 既存コードに対する品質向上（オプション - ブラウンフィールド開発）
 ```bash

--- a/tools/cc-sdd/README_zh-TW.md
+++ b/tools/cc-sdd/README_zh-TW.md
@@ -96,7 +96,7 @@ npx cc-sdd@latest --cursor --lang zh-TW # Cursor IDE 用
 
 > **規格作為基礎**：基於 [Kiro 的規格驅動方法論](https://kiro.dev/docs/specs/) - 規格將隨意開發轉換為系統工作流程，在明確的 AI-人類協作點將想法與實作連接。
 
-> **Kiro IDE 整合**：規格可移植到 [Kiro IDE](https://kiro.dev) - 以實作保護欄和團隊協作功能執行 `/kiro:spec-impl`。
+> **Kiro IDE 整合**：規格可移植到 [Kiro IDE](https://kiro.dev) - 提供強化的實作保護欄和團隊協作功能。
 
 ### 品質驗證（可選 - 棕地開發）
 ```bash


### PR DESCRIPTION
## Summary
- Fix misleading `/kiro:spec-impl` references in Kiro IDE integration descriptions
- Clarify that specs created by cc-sdd are portable to Kiro IDE for enhanced implementation
- Update descriptions consistently across English, Japanese, and Traditional Chinese READMEs

## Changes
- **English**: Removed confusing command reference, clarified portability
- **Japanese**: Updated to emphasize specs can be used/implemented in Kiro IDE  
- **Traditional Chinese**: Simplified to focus on enhanced implementation features

🤖 Generated with [Claude Code](https://claude.ai/code)