### PR TITLE
feat: add Qwen Code support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # cc-sdd / prev. Claude Code Spec
 
-✨ **Transform Claude Code/ Cursor IDE / Gemini CLI from prototype to production-ready development**
+✨ **Transform Claude Code/ Cursor IDE / Gemini CLI / Qwen Code from prototype to production-ready development**
 
 <!-- npm badges -->
 [![npm version](https://img.shields.io/npm/v/cc-sdd?logo=npm)](https://www.npmjs.com/package/cc-sdd?activeTab=readme)
@@ -12,7 +12,7 @@
 [![license: MIT](https://img.shields.io/badge/license-MIT-green.svg)](tools/cc-sdd/LICENSE)
 
 
-One command installs **AI-DLC** (AI-Driven Development Life Cycle) with **SDD** (Spec-Driven Development) workflows for Claude Code, Cursor IDE and Gemini CLI.
+One command installs **AI-DLC** (AI-Driven Development Life Cycle) with **SDD** (Spec-Driven Development) workflows for Claude Code, Cursor IDE, Gemini CLI and Qwen Code.
 
 ## 🚀 Quick Start
 
@@ -24,9 +24,10 @@ npx cc-sdd@latest
 # With OS: --os mac | --os windows | --os linux (if auto-detection fails)
 npx cc-sdd@latest --lang ja --os mac
 
-# With different agents: gemini-cli, cursor
+# With different agents: gemini-cli, cursor, qwen-code
 npx cc-sdd@latest --gemini-cli
 npx cc-sdd@latest --cursor
+npx cc-sdd@latest --qwen-code
 
 # Ready to go! Now Claude Code and Gemini CLI can leverage `/kiro:spec-init <what to build>` and the full SDD workflow
 ```
@@ -63,7 +64,7 @@ After running cc-sdd, you'll have:
 
 ## About
 
-Brings to Claude Code, Cursor IDE and Gemini CLI your project context, Project Memory (steering) and development patterns: **requirements → design → tasks → implementation**. **Kiro IDE compatible** — Reuse Kiro-style SDD specs and workflows seamlessly.
+Brings to Claude Code, Cursor IDE, Gemini CLI and Qwen Code your project context, Project Memory (steering) and development patterns: **requirements → design → tasks → implementation**. **Kiro IDE compatible** — Reuse Kiro-style SDD specs and workflows seamlessly.
 
 **【Claude Code/Cursor IDE/Gemini CLI】**
 ワンライナーで **AI-DLC（AI-Driven Development Life Cycle）** と **Spec-Driven Development（仕様駆動開発）** のワークフローを導入。プロジェクト直下に **10個のSlash Commands** 一式と設定ファイル（Claude Code用の **CLAUDE.md** / Cursor IDE用の **AGENTS.md** / Gemini CLI用の **GEMINI.md**）を配置、プロジェクトの文脈と開発パターン（**要件 → 設計 → タスク → 実装**）、**プロジェクトメモリ（ステアリング）** を含む。
@@ -86,6 +87,7 @@ Brings to Claude Code, Cursor IDE and Gemini CLI your project context, Project M
 - **✅ Claude Code** - Fully supported with all 10 custom slash commands and CLAUDE.md
 - **✅ Gemini CLI** - Fully supported with all 10 custom commands and GEMINI.md
 - **✅ Cursor IDE** - Fully supported with all 10 custom commands and AGENTS.md
+- **✅ Qwen Code** - Fully supported with all 10 custom commands and QWEN.md
 - **📅 More agents** - Additional AI coding assistants planned
 
 *Currently optimized for Claude Code. Use `--agent claude-code` (default) for full functionality.*
@@ -173,7 +175,7 @@ For detailed documentation, installation instructions, and usage examples, see:
 claude-code-spec/
 ├── tools/cc-sdd/              # Main cc-sdd NPM package
 │   ├── src/                   # TypeScript source code
-│   ├── templates/             # Agent templates (Claude Code, Cursor IDE, Gemini CLI)
+│   ├── templates/             # Agent templates (Claude Code, Cursor IDE, Gemini CLI, Qwen Code)
 │   ├── package.json           # Package configuration
 │   └── README.md              # Tool documentation
 ├── docs/                      # Documentation

--- a/tools/cc-sdd/README.md
+++ b/tools/cc-sdd/README.md
@@ -1,6 +1,6 @@
 # cc-sdd
 
-✨ **Transform Claude Code/ Cursor IDE / Gemini CLI from prototype to production-ready development**
+✨ **Transform Claude Code/ Cursor IDE / Gemini CLI / Qwen Code from prototype to production-ready development**
 
 <!-- npm badges -->
 [![npm version](https://img.shields.io/npm/v/cc-sdd?logo=npm)](https://www.npmjs.com/package/cc-sdd?activeTab=readme)
@@ -11,7 +11,7 @@
 English | <a href="https://github.com/gotalab/cc-sdd/blob/main/tools/cc-sdd/README_ja.md">日本語</a> | <a href="https://github.com/gotalab/cc-sdd/blob/main/tools/cc-sdd/README_zh-TW.md">繁體中文</a>
 </sub></div>
 
-Brings **AI-DLC (AI Driven Development Lifecycle)** to Claude Code, Cursor IDE and Gemini CLI. **AI-native processes** with **minimal human approval gates**: AI drives execution while humans validate critical decisions at each phase.
+Brings **AI-DLC (AI Driven Development Lifecycle)** to Claude Code, Cursor IDE, Gemini CLI, and Qwen Code. **AI-native processes** with **minimal human approval gates**: AI drives execution while humans validate critical decisions at each phase.
 
 🎯 **Perfect for**: Escaping the 70% overhead trap of traditional development (meetings, documentation, ceremonies) to achieve **weeks-to-hours delivery** with AI-native execution and human quality gates.
 
@@ -31,6 +31,7 @@ npx cc-sdd@latest --lang zh-TW # Traditional Chinese
 # With agent options (default: claude-code)
 npx cc-sdd@latest --gemini-cli --lang ja # For Gemini CLI instead
 npx cc-sdd@latest --cursor --lang ja # For Cursor IDE instead
+npx cc-sdd@latest --qwen-code --lang ja # For Qwen Code instead
 ```
 
 ## 🌐 Supported Languages
@@ -95,6 +96,7 @@ npx cc-sdd@latest --cursor --lang ja # For Cursor IDE instead
 | **Claude Code** | ✅ Full | 10 slash commands | `CLAUDE.md` |
 | **Gemini CLI** | ✅ Full | 10 commands | `GEMINI.md` |
 | **Cursor IDE** | ✅ Full | 10 commands | `AGENTS.md` |
+| **Qwen Code** | ✅ Full | 10 commands | `QWEN.md` |
 | Others | 📅 Planned | - | - |
  
 ## 📋 Commands

--- a/tools/cc-sdd/README_ja.md
+++ b/tools/cc-sdd/README_ja.md
@@ -1,6 +1,6 @@
 # cc-sdd
 
-✨ **Claude Code / Cursor IDE / Gemini CLIをプロトタイプからプロダクション開発プロセスへ**
+✨ **Claude Code / Cursor IDE / Gemini CLI / Qwen Codeをプロトタイプからプロダクション開発プロセスへ**
 
 <!-- npm badges -->
 [![npm version](https://img.shields.io/npm/v/cc-sdd?logo=npm)](https://www.npmjs.com/package/cc-sdd?activeTab=readme)
@@ -11,7 +11,7 @@
 <a href="https://github.com/gotalab/cc-sdd/blob/main/tools/cc-sdd/README.md">English</a> | 日本語 | <a href="https://github.com/gotalab/cc-sdd/blob/main/tools/cc-sdd/README_zh-TW.md">繁體中文</a>
 </sub></div>
 
-Claude Code、Cursor IDE、Gemini CLIを **AI-DLC (AI駆動開発ライフサイクル)**へ。**AIネイティブプロセス**と**最小限の人間承認ゲート**：AIが実行を駆動し、人間が各フェーズで重要な決定を検証。
+Claude Code、Cursor IDE、Gemini CLI、Qwen Codeを **AI-DLC (AI駆動開発ライフサイクル)**へ。**AIネイティブプロセス**と**最小限の人間承認ゲート**：AIが実行を駆動し、人間が各フェーズで重要な決定を検証。
 
 🎯 **最適な用途**: 従来開発の70%オーバーヘッド（会議・文書・儀式）から脱却し、AIネイティブ実行と人間品質ゲートで **週単位から時間単位の納期** を実現。
 
@@ -31,6 +31,7 @@ npx cc-sdd@latest --lang zh-TW # 繁体字中国語
 # エージェントオプション（デフォルト: claude-code）
 npx cc-sdd@latest --gemini-cli --lang ja # Gemini CLI用
 npx cc-sdd@latest --cursor --lang ja # Cursor IDE用
+npx cc-sdd@latest --qwen-code --lang ja # Qwen Code用
 ```
 
 ## ✨ クイックスタート
@@ -80,6 +81,7 @@ npx cc-sdd@latest --cursor --lang ja # Cursor IDE用
 | **Claude Code** | ✅ 完全対応 | 10スラッシュコマンド | `CLAUDE.md` |
 | **Gemini CLI** | ✅ 完全対応 | 10コマンド | `GEMINI.md` |
 | **Cursor IDE** | ✅ 完全対応 | 10コマンド | `AGENTS.md` |
+| **Qwen Code** | ✅ 完全対応 | 10コマンド | `QWEN.md` |
 | その他 | 📅 予定 | - | - |
  
 ## 📋 コマンド

--- a/tools/cc-sdd/README_zh-TW.md
+++ b/tools/cc-sdd/README_zh-TW.md
@@ -1,6 +1,6 @@
 # cc-sdd
 
-✨ **將 Claude Code / Cursor IDE / Gemini CLI 從原型開發轉型為生產級開發**
+✨ **將 Claude Code / Cursor IDE / Gemini CLI / Qwen Code 從原型開發轉型為生產級開發**
 
 <!-- npm badges -->
 [![npm version](https://img.shields.io/npm/v/cc-sdd?logo=npm)](https://www.npmjs.com/package/cc-sdd?activeTab=readme)
@@ -11,7 +11,7 @@
 <a href="https://github.com/gotalab/cc-sdd/blob/main/tools/cc-sdd/README.md">English</a> | <a href="https://github.com/gotalab/cc-sdd/blob/main/tools/cc-sdd/README_ja.md">日本語</a> | 繁體中文
 </sub></div>
 
-將 **AI-DLC (AI 驅動開發生命週期)** 帶入 Claude Code、Cursor IDE 與 Gemini CLI。**AI 原生流程**與**最小限的人類批准關卡**：AI 驅動執行，人類在各階段驗證關鍵決策。
+將 **AI-DLC (AI 驅動開發生命週期)** 帶入 Claude Code、Cursor IDE、Gemini CLI 與 Qwen Code。**AI 原生流程**與**最小限的人類批准關卡**：AI 驅動執行，人類在各階段驗證關鍵決策。
 
 🎯 **最佳用途**：脱離傳統開發 70% 的額外負擔（會議、文件、儀式），透過 AI 原生執行和人類品質關卡實現 **從週到小時的交付**。
 
@@ -31,6 +31,7 @@ npx cc-sdd@latest --lang ja    # 日語
 # 代理選項（預設：claude-code）
 npx cc-sdd@latest --gemini-cli --lang zh-TW # Gemini CLI 用
 npx cc-sdd@latest --cursor --lang zh-TW # Cursor IDE 用
+npx cc-sdd@latest --qwen-code --lang zh-TW # Qwen Code 用
 ```
 
 ## ✨ 快速開始
@@ -80,6 +81,7 @@ npx cc-sdd@latest --cursor --lang zh-TW # Cursor IDE 用
 | **Claude Code** | ✅ 完全支援 | 10 個斜線指令 | `CLAUDE.md` |
 | **Gemini CLI** | ✅ 完全支援 | 10 個指令 | `GEMINI.md` |
 | **Cursor IDE** | ✅ 完全支援 | 10 個指令 | `AGENTS.md` |
+| **Qwen Code** | ✅ 完全支援 | 10 個指令 | `QWEN.md` |
 | 其他 | 📅 規劃中 | - | - |
 
 ## 📋 指令

--- a/tools/cc-sdd/package.json
+++ b/tools/cc-sdd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-sdd",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Transform your coding workflow with AI-DLC and Spec-Driven Development. One command installs 7 powerful slash commands, Project Memory, and structured development workflows for Claude Code.",
   "keywords": ["claude-code", "spec-driven-development", "kiro", "steering", "ai-development", "tdd", "ai-dlc", "ai-driven-development-life-cycle"],
   "author": "Gota",

--- a/tools/cc-sdd/src/resolvers/agentLayout.ts
+++ b/tools/cc-sdd/src/resolvers/agentLayout.ts
@@ -23,7 +23,7 @@ export const resolveAgentLayout = (agent: AgentType, config?: CCSddConfig): Agen
       docFile: 'GEMINI.md',
     },
     'qwen-code': {
-      commandsDir: '.qwen/commands',
+      commandsDir: '.qwen/commands/kiro',
       agentDir: '.qwen',
       docFile: 'QWEN.md',
     },

--- a/tools/cc-sdd/templates/agents/qwen-code/docs/QWEN.tpl.md
+++ b/tools/cc-sdd/templates/agents/qwen-code/docs/QWEN.tpl.md
@@ -1,0 +1,71 @@
+# Qwen Code Spec-Driven Development
+
+Kiro-style Spec Driven Development implementation using qwen code slash commands.
+
+## Project Context
+
+### Paths
+- Steering: `{{KIRO_DIR}}/steering/`
+- Specs: `{{KIRO_DIR}}/specs/`
+- Commands: `{{AGENT_DIR}}/commands/`
+
+### Steering vs Specification
+
+**Steering** (`{{KIRO_DIR}}/steering/`) - Guide AI with project-wide rules and context
+**Specs** (`{{KIRO_DIR}}/specs/`) - Formalize development process for individual features
+
+### Active Specifications
+- Check `{{KIRO_DIR}}/specs/` for active specifications
+- Use `/kiro:spec-status [feature-name]` to check progress
+
+## Development Guidelines
+{{DEV_GUIDELINES}}
+
+## Workflow
+
+### Phase 0: Steering (Optional)
+`/kiro:steering` - Create/update steering documents
+`/kiro:steering-custom` - Create custom steering for specialized contexts
+
+Note: Optional for new features or small additions. You can proceed directly to spec-init.
+
+### Phase 1: Specification Creation
+1. `/kiro:spec-init [detailed description]` - Initialize spec with detailed project description
+2. `/kiro:spec-requirements [feature]` - Generate requirements document
+3. `/kiro:spec-design [feature]` - Interactive: "Have you reviewed requirements.md? [y/N]"
+4. `/kiro:spec-tasks [feature]` - Interactive: Confirms both requirements and design review
+
+### Phase 2: Progress Tracking
+`/kiro:spec-status [feature]` - Check current progress and phases
+
+## Development Rules
+1. **Consider steering**: Run `/kiro:steering` before major development (optional for new features)
+2. **Follow 3-phase approval workflow**: Requirements → Design → Tasks → Implementation
+3. **Approval required**: Each phase requires human review (interactive prompt or manual)
+4. **No skipping phases**: Design requires approved requirements; Tasks require approved design
+5. **Update task status**: Mark tasks as completed when working on them
+6. **Keep steering current**: Run `/kiro:steering` after significant changes
+7. **Check spec compliance**: Use `/kiro:spec-status` to verify alignment
+
+## Steering Configuration
+
+### Current Steering Files
+Managed by `/kiro:steering` command. Updates here reflect command changes.
+
+### Active Steering Files
+- `product.md`: Always included - Product context and business objectives
+- `tech.md`: Always included - Technology stack and architectural decisions
+- `structure.md`: Always included - File organization and code patterns
+
+### Custom Steering Files
+<!-- Added by /kiro:steering-custom command -->
+<!-- Format:
+- `filename.md`: Mode - Pattern(s) - Description
+  Mode: Always|Conditional|Manual
+  Pattern: File patterns for Conditional mode
+-->
+
+### Inclusion Modes
+- **Always**: Loaded in every interaction (default)
+- **Conditional**: Loaded for specific file patterns (e.g., "*.test.js")
+- **Manual**: Reference with `@filename.md` syntax

--- a/tools/cc-sdd/templates/manifests/qwen-code.json
+++ b/tools/cc-sdd/templates/manifests/qwen-code.json
@@ -1,0 +1,33 @@
+{
+  "version": 1,
+  "artifacts": [
+    {
+      "id": "commands_os_mac",
+      "source": {
+        "type": "templateDir",
+        "fromDir": "templates/agents/gemini-cli/commands/os-mac",
+        "toDir": "{{AGENT_COMMANDS_DIR}}"
+      },
+      "when": { "agent": "qwen-code", "os": ["mac"] }
+    },
+    {
+      "id": "commands_os_windows",
+      "source": {
+        "type": "templateDir",
+        "fromDir": "templates/agents/gemini-cli/commands/os-windows",
+        "toDir": "{{AGENT_COMMANDS_DIR}}"
+      },
+      "when": { "agent": "qwen-code", "os": ["windows", "linux"] }
+    },
+    {
+      "id": "doc_main",
+      "source": {
+        "type": "templateFile",
+        "from": "templates/agents/{{AGENT}}/docs/QWEN.tpl.md",
+        "toDir": ".",
+        "rename": "{{AGENT_DOC}}"
+      },
+      "when": { "agent": "qwen-code" }
+    }
+  ]
+}

--- a/tools/cc-sdd/test/templateFromResolved.test.ts
+++ b/tools/cc-sdd/test/templateFromResolved.test.ts
@@ -46,7 +46,7 @@ describe('contextFromResolved', () => {
     expect(ctx.KIRO_DIR).toBe('.kiro');
     expect(ctx.AGENT_DIR).toBe('.qwen');
     expect(ctx.AGENT_DOC).toBe('QWEN.md');
-    expect(ctx.AGENT_COMMANDS_DIR).toBe('.qwen/commands');
+    expect(ctx.AGENT_COMMANDS_DIR).toBe('.qwen/commands/kiro');
     expect(ctx.DEV_GUIDELINES).toBe('- 以英文思考，但以繁體中文生成回應（Think in English, generate in Traditional Chinese）');
   });
 


### PR DESCRIPTION
## Summary
- Add full support for Qwen Code AI assistant
- Reuse gemini-cli templates to minimize code duplication
- Bump version to 1.1.5

## Changes
- Update command directory path to `.qwen/commands/kiro`
- Create qwen-code manifest and QWEN.md template
- Update all README files with Qwen Code support

🤖 Generated with [Claude Code](https://claude.ai/code)