### PR TITLE
feat(skills): require executed-mutation evidence for counterfactual claims

### DIFF
--- a/tools/cc-sdd/templates/agents/antigravity-skills/skills/kiro-impl/templates/debugger-prompt.md
+++ b/tools/cc-sdd/templates/agents/antigravity-skills/skills/kiro-impl/templates/debugger-prompt.md
@@ -36,6 +36,8 @@ Do not collapse this investigation into guess-first patching; preserve category 
 
 ## Critical Rule
 
+**Never state what a mutation would do without executing it.** A root-cause claim of the form "restoring X would reproduce the failure" or "removing Y would make it pass" is a measurement, not an inference — run it, report the real output, and restore the file from a saved copy rather than a destructive VCS command.
+
 Use `NEXT_ACTION: STOP_FOR_HUMAN` only when the fix genuinely requires something outside the repository or the approved task plan is no longer safe to continue. If the fix is adding a dependency, changing a config file, or restructuring code inside the current task plan, prefer `NEXT_ACTION: RETRY_TASK`.
 
 ## Output
@@ -49,6 +51,7 @@ Use `NEXT_ACTION: STOP_FOR_HUMAN` only when the fix genuinely requires something
   2. <specific action with file path>
   ...
 - VERIFICATION: <command(s) to run after fix to confirm resolution>
+- MUTATIONS_EXECUTED: <every mutation you actually ran while isolating the cause, with its real output. NONE if you ran none>
 - NEXT_ACTION: RETRY_TASK | BLOCK_TASK | STOP_FOR_HUMAN
 - CONFIDENCE: HIGH | MEDIUM | LOW
 - NOTES: <any additional context the next implementer should know>

--- a/tools/cc-sdd/templates/agents/antigravity-skills/skills/kiro-impl/templates/implementer-prompt.md
+++ b/tools/cc-sdd/templates/agents/antigravity-skills/skills/kiro-impl/templates/implementer-prompt.md
@@ -57,6 +57,7 @@ If any of these cannot be determined from the spec — the requirements are too 
 - Verify the tests prove the required behavior, not just scaffolding or a happy-path shell
 - Verify that any namespace or qualified-name access used at runtime (for example `React.X`, `module.Foo`, `pkg.Bar`) has a real value import or runtime binding, not only a type-only import or ambient type reference
 - Verify that any newly introduced runtime-sensitive dependency or packaging assumption (native modules, module-format boundaries, generated assets, required env vars, boot-time config) is reflected in validation or called out explicitly in `CONCERNS`
+- Verify that every **counterfactual claim** you wrote — in a code comment, in a test's explanatory note, or in your own status report — names a mutation you actually executed and cites its real output. A **counterfactual claim** is any statement of the form "if X were removed / restored / inverted, this check would fail / stay green". If you did not run it, delete the claim or run it now. Restore every mutation from a saved copy of the file, never with a destructive VCS command
 - If any review check fails, fix the implementation, re-run validation, and repeat this step
 
 ## Critical Constraints
@@ -64,6 +65,7 @@ If any of these cannot be determined from the spec — the requirements are too 
 - Do NOT create commits
 - Do NOT expand scope beyond the assigned task and boundary
 - Do NOT silently work around requirement or design mismatches
+- Do NOT claim that a mutation "would fail" or "would pass" without having executed it and reported its output
 - Use the exact section numbers from `requirements.md` and `design.md` in all notes and reports; do NOT invent `REQ-*` aliases
 - Do NOT stop at a mock, stub, placeholder, fake, or TODO-only implementation unless the task explicitly requires it
 - Prefer the minimal implementation that satisfies the Task Brief and tests
@@ -84,6 +86,7 @@ The parent controller parses the exact `- STATUS:` line. Do NOT rename the headi
 - REQUIREMENTS_CHECKED: <exact section numbers from requirements.md>
 - DESIGN_CHECKED: <exact section numbers from design.md>
 - RED_PHASE_OUTPUT: <test command and failing output from before implementation -- proves tests were written first>
+- MUTATIONS_EXECUTED: <for every counterfactual claim you wrote anywhere: the exact mutation, the command you ran, and its real output. Write NONE if you wrote no counterfactual claim>
 - TESTS_RUN: <test commands and final passing results>
 - CONCERNS: <optional -- describe any non-blocking concerns the reviewer should pay attention to>
 - BLOCKER: <only for BLOCKED -- describe what prevents completion>

--- a/tools/cc-sdd/templates/agents/antigravity-skills/skills/kiro-impl/templates/reviewer-prompt.md
+++ b/tools/cc-sdd/templates/agents/antigravity-skills/skills/kiro-impl/templates/reviewer-prompt.md
@@ -54,6 +54,11 @@ Evaluate each item. If ANY item fails, the verdict is REJECTED.
 - If the task is behavioral and RED_PHASE_OUTPUT is missing or empty → REJECTED (tests may not have been written before implementation).
 - The output should show test failures related to the task's acceptance criteria.
 
+**5.5 Executed-Mutation Evidence**
+- A **counterfactual claim** is any statement of the form "if X were removed / restored / inverted, this check would fail / stay green".
+- Read the diff and the implementer's status report. If a counterfactual claim names no executed mutation and cites no output → REJECTED.
+- **This binds you too.** Do not write such a claim in a finding unless you ran the mutation and are reporting its real output. Restore every mutation from a saved copy of the file, never with a destructive VCS command.
+
 ### Judgment Checks (read code, compare to spec)
 
 **6. Reality Check**
@@ -102,6 +107,7 @@ The parent controller parses the exact `- VERDICT:` line. Do NOT rename the head
   - Secrets grep: CLEAN | <count> matches
   - Boundary: WITHIN | <files outside boundary>
   - RED phase: VERIFIED | MISSING | N/A (non-behavioral task)
+  - Counterfactual evidence: CLEAN | <claims asserted without an executed mutation>
 - FINDINGS:
   - <numbered list of specific findings, if any>
   - <reference exact file paths, line ranges, and spec section numbers>

--- a/tools/cc-sdd/templates/agents/antigravity-skills/skills/kiro-review/SKILL.md
+++ b/tools/cc-sdd/templates/agents/antigravity-skills/skills/kiro-review/SKILL.md
@@ -86,6 +86,13 @@ Run these checks and use the result as primary signal.
 - For behavioral tasks, verify that the implementer status report includes `RED_PHASE_OUTPUT`.
 - Reject if RED evidence is missing, empty, or unrelated to the task's acceptance criteria.
 
+### 5.5 Executed-Mutation Evidence
+- A **counterfactual claim** is any statement of the form "if X were removed / restored / inverted, this check would fail / stay green".
+- Wherever such a claim appears — in code comments, in a test's explanatory note, in the implementer's status report, **or in your own review findings** — it must name the mutation that was actually executed and cite its real output (failing count out of the total, or the measured result).
+- Reject an implementation whose comments or status report assert a counterfactual without cited evidence.
+- **This binds you too.** A counterfactual is a measurement, not an intuition: do not write one in a finding unless you ran the mutation.
+- Restore every mutation you make from a saved copy of the file. Never use a destructive VCS command to undo one.
+
 ### 6. Runtime-Sensitive Static Checks
 - If the project already has lint or equivalent static analysis for the touched stack, run the relevant command for the task boundary.
 - Pay attention to patterns that can survive typecheck/build yet fail at runtime: type-only imports used as values, missing namespace value imports for qualified-name access, unresolved globals, and newly introduced runtime-sensitive dependencies without matching boot/runtime handling.
@@ -147,6 +154,7 @@ Escalate instead of papering over the issue when:
 | “Tests pass, so approve” | Passing tests do not prove spec compliance or boundary respect. |
 | “The extra behavior is useful” | Extra behavior outside approved scope is still drift. |
 | “The implementer said RED was done” | RED must be evidenced, not asserted. |
+| “Removing that would obviously break the check” | A counterfactual is a measurement, not an intuition. Run the mutation and cite the output, or do not write the claim. |
 | “This gap is small enough to let through” | Real gaps must be rejected or escalated. |
 
 ## Output Format
@@ -163,6 +171,7 @@ Escalate instead of papering over the issue when:
   - Boundary: WITHIN | <files outside boundary>
   - Boundary audit: CLEAN | <spillover / hidden dependency findings>
   - RED phase: VERIFIED | MISSING | N/A
+  - Counterfactual evidence: CLEAN | <claims asserted without an executed mutation>
 - FINDINGS:
   1. <specific finding with exact files/spec refs>
 - REMEDIATION: <mandatory if REJECTED>

--- a/tools/cc-sdd/templates/agents/claude-code-skills/skills/kiro-impl/templates/debugger-prompt.md
+++ b/tools/cc-sdd/templates/agents/claude-code-skills/skills/kiro-impl/templates/debugger-prompt.md
@@ -33,6 +33,8 @@ You are a fresh debug investigator with NO prior context about implementation at
 
 ## Critical Rule
 
+**Never state what a mutation would do without executing it.** A root-cause claim of the form "restoring X would reproduce the failure" or "removing Y would make it pass" is a measurement, not an inference — run it, report the real output, and restore the file from a saved copy rather than a destructive VCS command.
+
 Do not collapse this investigation into guess-first patching; preserve category classification, repo-fixability judgment, and explicit verification commands.
 
 Use `NEXT_ACTION: STOP_FOR_HUMAN` only when the fix genuinely requires something outside the repository or the approved task plan is no longer safe to continue. If the fix is adding a dependency, changing a config file, or restructuring code inside the current task plan, prefer `NEXT_ACTION: RETRY_TASK`.
@@ -48,6 +50,7 @@ Use `NEXT_ACTION: STOP_FOR_HUMAN` only when the fix genuinely requires something
   2. <specific action with file path>
   ...
 - VERIFICATION: <command(s) to run after fix to confirm resolution>
+- MUTATIONS_EXECUTED: <every mutation you actually ran while isolating the cause, with its real output. NONE if you ran none>
 - NEXT_ACTION: RETRY_TASK | BLOCK_TASK | STOP_FOR_HUMAN
 - CONFIDENCE: HIGH | MEDIUM | LOW
 - NOTES: <any additional context the next implementer should know>

--- a/tools/cc-sdd/templates/agents/claude-code-skills/skills/kiro-impl/templates/implementer-prompt.md
+++ b/tools/cc-sdd/templates/agents/claude-code-skills/skills/kiro-impl/templates/implementer-prompt.md
@@ -57,6 +57,7 @@ If any of these cannot be determined from the spec — the requirements are too 
 - Verify the tests prove the required behavior, not just scaffolding or a happy-path shell
 - Verify that any namespace or qualified-name access used at runtime (for example `React.X`, `module.Foo`, `pkg.Bar`) has a real value import or runtime binding, not only a type-only import or ambient type reference
 - Verify that any newly introduced runtime-sensitive dependency or packaging assumption (native modules, module-format boundaries, generated assets, required env vars, boot-time config) is reflected in validation or called out explicitly in `CONCERNS`
+- Verify that every **counterfactual claim** you wrote — in a code comment, in a test's explanatory note, or in your own status report — names a mutation you actually executed and cites its real output. A **counterfactual claim** is any statement of the form "if X were removed / restored / inverted, this check would fail / stay green". If you did not run it, delete the claim or run it now. Restore every mutation from a saved copy of the file, never with a destructive VCS command
 - If any review check fails, fix the implementation, re-run validation, and repeat this step
 
 ## Critical Constraints
@@ -64,6 +65,7 @@ If any of these cannot be determined from the spec — the requirements are too 
 - Do NOT create commits
 - Do NOT expand scope beyond the assigned task and boundary
 - Do NOT silently work around requirement or design mismatches
+- Do NOT claim that a mutation "would fail" or "would pass" without having executed it and reported its output
 - Use the exact section numbers from `requirements.md` and `design.md` in all notes and reports; do NOT invent `REQ-*` aliases
 - Do NOT stop at a mock, stub, placeholder, fake, or TODO-only implementation unless the task explicitly requires it
 - Prefer the minimal implementation that satisfies the Task Brief and tests
@@ -84,6 +86,7 @@ The parent controller parses the exact `- STATUS:` line. Do NOT rename the headi
 - REQUIREMENTS_CHECKED: <exact section numbers from requirements.md>
 - DESIGN_CHECKED: <exact section numbers from design.md>
 - RED_PHASE_OUTPUT: <test command and failing output from before implementation -- proves tests were written first>
+- MUTATIONS_EXECUTED: <for every counterfactual claim you wrote anywhere: the exact mutation, the command you ran, and its real output. Write NONE if you wrote no counterfactual claim>
 - TESTS_RUN: <test commands and final passing results>
 - CONCERNS: <optional -- describe any non-blocking concerns the reviewer should pay attention to>
 - BLOCKER: <only for BLOCKED -- describe what prevents completion>

--- a/tools/cc-sdd/templates/agents/claude-code-skills/skills/kiro-impl/templates/reviewer-prompt.md
+++ b/tools/cc-sdd/templates/agents/claude-code-skills/skills/kiro-impl/templates/reviewer-prompt.md
@@ -53,6 +53,11 @@ Evaluate each item. If ANY item fails, the verdict is REJECTED.
 - If the task is behavioral and RED_PHASE_OUTPUT is missing or empty → REJECTED (tests may not have been written before implementation).
 - The output should show test failures related to the task's acceptance criteria.
 
+**5.5 Executed-Mutation Evidence**
+- A **counterfactual claim** is any statement of the form "if X were removed / restored / inverted, this check would fail / stay green".
+- Read the diff and the implementer's status report. If a counterfactual claim names no executed mutation and cites no output → REJECTED.
+- **This binds you too.** Do not write such a claim in a finding unless you ran the mutation and are reporting its real output. Restore every mutation from a saved copy of the file, never with a destructive VCS command.
+
 ### Judgment Checks (read code, compare to spec)
 
 **6. Reality Check**
@@ -101,6 +106,7 @@ The parent controller parses the exact `- VERDICT:` line. Do NOT rename the head
   - Secrets grep: CLEAN | <count> matches
   - Boundary: WITHIN | <files outside boundary>
   - RED phase: VERIFIED | MISSING | N/A (non-behavioral task)
+  - Counterfactual evidence: CLEAN | <claims asserted without an executed mutation>
 - FINDINGS:
   - <numbered list of specific findings, if any>
   - <reference exact file paths, line ranges, and spec section numbers>

--- a/tools/cc-sdd/templates/agents/claude-code-skills/skills/kiro-review/SKILL.md
+++ b/tools/cc-sdd/templates/agents/claude-code-skills/skills/kiro-review/SKILL.md
@@ -87,6 +87,13 @@ Run these checks and use the result as primary signal.
 - For behavioral tasks, verify that the implementer status report includes `RED_PHASE_OUTPUT`.
 - Reject if RED evidence is missing, empty, or unrelated to the task's acceptance criteria.
 
+### 5.5 Executed-Mutation Evidence
+- A **counterfactual claim** is any statement of the form "if X were removed / restored / inverted, this check would fail / stay green".
+- Wherever such a claim appears — in code comments, in a test's explanatory note, in the implementer's status report, **or in your own review findings** — it must name the mutation that was actually executed and cite its real output (failing count out of the total, or the measured result).
+- Reject an implementation whose comments or status report assert a counterfactual without cited evidence.
+- **This binds you too.** A counterfactual is a measurement, not an intuition: do not write one in a finding unless you ran the mutation.
+- Restore every mutation you make from a saved copy of the file. Never use a destructive VCS command to undo one.
+
 ### 6. Runtime-Sensitive Static Checks
 - If the project already has lint or equivalent static analysis for the touched stack, run the relevant command for the task boundary.
 - Pay attention to patterns that can survive typecheck/build yet fail at runtime: type-only imports used as values, missing namespace value imports for qualified-name access, unresolved globals, and newly introduced runtime-sensitive dependencies without matching boot/runtime handling.
@@ -148,6 +155,7 @@ Escalate instead of papering over the issue when:
 | “Tests pass, so approve” | Passing tests do not prove spec compliance or boundary respect. |
 | “The extra behavior is useful” | Extra behavior outside approved scope is still drift. |
 | “The implementer said RED was done” | RED must be evidenced, not asserted. |
+| “Removing that would obviously break the check” | A counterfactual is a measurement, not an intuition. Run the mutation and cite the output, or do not write the claim. |
 | “This gap is small enough to let through” | Real gaps must be rejected or escalated. |
 
 ## Output Format
@@ -164,6 +172,7 @@ Escalate instead of papering over the issue when:
   - Boundary: WITHIN | <files outside boundary>
   - Boundary audit: CLEAN | <spillover / hidden dependency findings>
   - RED phase: VERIFIED | MISSING | N/A
+  - Counterfactual evidence: CLEAN | <claims asserted without an executed mutation>
 - FINDINGS:
   1. <specific finding with exact files/spec refs>
 - REMEDIATION: <mandatory if REJECTED>

--- a/tools/cc-sdd/templates/agents/codex-skills/skills/kiro-impl/templates/debugger-prompt.md
+++ b/tools/cc-sdd/templates/agents/codex-skills/skills/kiro-impl/templates/debugger-prompt.md
@@ -33,6 +33,8 @@ You are a fresh debug investigator with NO prior context about implementation at
 
 ## Critical Rule
 
+**Never state what a mutation would do without executing it.** A root-cause claim of the form "restoring X would reproduce the failure" or "removing Y would make it pass" is a measurement, not an inference — run it, report the real output, and restore the file from a saved copy rather than a destructive VCS command.
+
 Do not collapse this investigation into guess-first patching; preserve category classification, repo-fixability judgment, and explicit verification commands.
 
 Use `NEXT_ACTION: STOP_FOR_HUMAN` only when the fix genuinely requires something outside the repository or the approved task plan is no longer safe to continue. If the fix is adding a dependency, changing a config file, or restructuring code inside the current task plan, prefer `NEXT_ACTION: RETRY_TASK`.
@@ -48,6 +50,7 @@ Use `NEXT_ACTION: STOP_FOR_HUMAN` only when the fix genuinely requires something
   2. <specific action with file path>
   ...
 - VERIFICATION: <command(s) to run after fix to confirm resolution>
+- MUTATIONS_EXECUTED: <every mutation you actually ran while isolating the cause, with its real output. NONE if you ran none>
 - NEXT_ACTION: RETRY_TASK | BLOCK_TASK | STOP_FOR_HUMAN
 - CONFIDENCE: HIGH | MEDIUM | LOW
 - NOTES: <any additional context the next implementer should know>

--- a/tools/cc-sdd/templates/agents/codex-skills/skills/kiro-impl/templates/implementer-prompt.md
+++ b/tools/cc-sdd/templates/agents/codex-skills/skills/kiro-impl/templates/implementer-prompt.md
@@ -57,6 +57,7 @@ If any of these cannot be determined from the spec — the requirements are too 
 - Verify the tests prove the required behavior, not just scaffolding or a happy-path shell
 - Verify that any namespace or qualified-name access used at runtime (for example `React.X`, `module.Foo`, `pkg.Bar`) has a real value import or runtime binding, not only a type-only import or ambient type reference
 - Verify that any newly introduced runtime-sensitive dependency or packaging assumption (native modules, module-format boundaries, generated assets, required env vars, boot-time config) is reflected in validation or called out explicitly in `CONCERNS`
+- Verify that every **counterfactual claim** you wrote — in a code comment, in a test's explanatory note, or in your own status report — names a mutation you actually executed and cites its real output. A **counterfactual claim** is any statement of the form "if X were removed / restored / inverted, this check would fail / stay green". If you did not run it, delete the claim or run it now. Restore every mutation from a saved copy of the file, never with a destructive VCS command
 - If any review check fails, fix the implementation, re-run validation, and repeat this step
 
 ## Critical Constraints
@@ -64,6 +65,7 @@ If any of these cannot be determined from the spec — the requirements are too 
 - Do NOT create commits
 - Do NOT expand scope beyond the assigned task and boundary
 - Do NOT silently work around requirement or design mismatches
+- Do NOT claim that a mutation "would fail" or "would pass" without having executed it and reported its output
 - Use the exact section numbers from `requirements.md` and `design.md` in all notes and reports; do NOT invent `REQ-*` aliases
 - Do NOT stop at a mock, stub, placeholder, fake, or TODO-only implementation unless the task explicitly requires it
 - Prefer the minimal implementation that satisfies the Task Brief and tests
@@ -84,6 +86,7 @@ The parent controller parses the exact `- STATUS:` line. Do NOT rename the headi
 - REQUIREMENTS_CHECKED: <exact section numbers from requirements.md>
 - DESIGN_CHECKED: <exact section numbers from design.md>
 - RED_PHASE_OUTPUT: <test command and failing output from before implementation -- proves tests were written first>
+- MUTATIONS_EXECUTED: <for every counterfactual claim you wrote anywhere: the exact mutation, the command you ran, and its real output. Write NONE if you wrote no counterfactual claim>
 - TESTS_RUN: <test commands and final passing results>
 - CONCERNS: <optional -- describe any non-blocking concerns the reviewer should pay attention to>
 - BLOCKER: <only for BLOCKED -- describe what prevents completion>

--- a/tools/cc-sdd/templates/agents/codex-skills/skills/kiro-impl/templates/reviewer-prompt.md
+++ b/tools/cc-sdd/templates/agents/codex-skills/skills/kiro-impl/templates/reviewer-prompt.md
@@ -53,6 +53,11 @@ Evaluate each item. If ANY item fails, the verdict is REJECTED.
 - If the task is behavioral and RED_PHASE_OUTPUT is missing or empty → REJECTED (tests may not have been written before implementation).
 - The output should show test failures related to the task's acceptance criteria.
 
+**5.5 Executed-Mutation Evidence**
+- A **counterfactual claim** is any statement of the form "if X were removed / restored / inverted, this check would fail / stay green".
+- Read the diff and the implementer's status report. If a counterfactual claim names no executed mutation and cites no output → REJECTED.
+- **This binds you too.** Do not write such a claim in a finding unless you ran the mutation and are reporting its real output. Restore every mutation from a saved copy of the file, never with a destructive VCS command.
+
 ### Judgment Checks (read code, compare to spec)
 
 **6. Reality Check**
@@ -101,6 +106,7 @@ The parent controller parses the exact `- VERDICT:` line. Do NOT rename the head
   - Secrets grep: CLEAN | <count> matches
   - Boundary: WITHIN | <files outside boundary>
   - RED phase: VERIFIED | MISSING | N/A (non-behavioral task)
+  - Counterfactual evidence: CLEAN | <claims asserted without an executed mutation>
 - FINDINGS:
   - <numbered list of specific findings, if any>
   - <reference exact file paths, line ranges, and spec section numbers>

--- a/tools/cc-sdd/templates/agents/codex-skills/skills/kiro-review/SKILL.md
+++ b/tools/cc-sdd/templates/agents/codex-skills/skills/kiro-review/SKILL.md
@@ -86,6 +86,13 @@ Run these checks and use the result as primary signal.
 - For behavioral tasks, verify that the implementer status report includes `RED_PHASE_OUTPUT`.
 - Reject if RED evidence is missing, empty, or unrelated to the task's acceptance criteria.
 
+### 5.5 Executed-Mutation Evidence
+- A **counterfactual claim** is any statement of the form "if X were removed / restored / inverted, this check would fail / stay green".
+- Wherever such a claim appears — in code comments, in a test's explanatory note, in the implementer's status report, **or in your own review findings** — it must name the mutation that was actually executed and cite its real output (failing count out of the total, or the measured result).
+- Reject an implementation whose comments or status report assert a counterfactual without cited evidence.
+- **This binds you too.** A counterfactual is a measurement, not an intuition: do not write one in a finding unless you ran the mutation.
+- Restore every mutation you make from a saved copy of the file. Never use a destructive VCS command to undo one.
+
 ### 6. Runtime-Sensitive Static Checks
 - If the project already has lint or equivalent static analysis for the touched stack, run the relevant command for the task boundary.
 - Pay attention to patterns that can survive typecheck/build yet fail at runtime: type-only imports used as values, missing namespace value imports for qualified-name access, unresolved globals, and newly introduced runtime-sensitive dependencies without matching boot/runtime handling.
@@ -147,6 +154,7 @@ Escalate instead of papering over the issue when:
 | “Tests pass, so approve” | Passing tests do not prove spec compliance or boundary respect. |
 | “The extra behavior is useful” | Extra behavior outside approved scope is still drift. |
 | “The implementer said RED was done” | RED must be evidenced, not asserted. |
+| “Removing that would obviously break the check” | A counterfactual is a measurement, not an intuition. Run the mutation and cite the output, or do not write the claim. |
 | “This gap is small enough to let through” | Real gaps must be rejected or escalated. |
 
 ## Output Format
@@ -163,6 +171,7 @@ Escalate instead of papering over the issue when:
   - Boundary: WITHIN | <files outside boundary>
   - Boundary audit: CLEAN | <spillover / hidden dependency findings>
   - RED phase: VERIFIED | MISSING | N/A
+  - Counterfactual evidence: CLEAN | <claims asserted without an executed mutation>
 - FINDINGS:
   1. <specific finding with exact files/spec refs>
 - REMEDIATION: <mandatory if REJECTED>

--- a/tools/cc-sdd/templates/agents/cursor-skills/skills/kiro-impl/templates/debugger-prompt.md
+++ b/tools/cc-sdd/templates/agents/cursor-skills/skills/kiro-impl/templates/debugger-prompt.md
@@ -36,6 +36,8 @@ Do not collapse this investigation into guess-first patching; preserve category 
 
 ## Critical Rule
 
+**Never state what a mutation would do without executing it.** A root-cause claim of the form "restoring X would reproduce the failure" or "removing Y would make it pass" is a measurement, not an inference — run it, report the real output, and restore the file from a saved copy rather than a destructive VCS command.
+
 Use `NEXT_ACTION: STOP_FOR_HUMAN` only when the fix genuinely requires something outside the repository or the approved task plan is no longer safe to continue. If the fix is adding a dependency, changing a config file, or restructuring code inside the current task plan, prefer `NEXT_ACTION: RETRY_TASK`.
 
 ## Output
@@ -49,6 +51,7 @@ Use `NEXT_ACTION: STOP_FOR_HUMAN` only when the fix genuinely requires something
   2. <specific action with file path>
   ...
 - VERIFICATION: <command(s) to run after fix to confirm resolution>
+- MUTATIONS_EXECUTED: <every mutation you actually ran while isolating the cause, with its real output. NONE if you ran none>
 - NEXT_ACTION: RETRY_TASK | BLOCK_TASK | STOP_FOR_HUMAN
 - CONFIDENCE: HIGH | MEDIUM | LOW
 - NOTES: <any additional context the next implementer should know>

--- a/tools/cc-sdd/templates/agents/cursor-skills/skills/kiro-impl/templates/implementer-prompt.md
+++ b/tools/cc-sdd/templates/agents/cursor-skills/skills/kiro-impl/templates/implementer-prompt.md
@@ -57,6 +57,7 @@ If any of these cannot be determined from the spec — the requirements are too 
 - Verify the tests prove the required behavior, not just scaffolding or a happy-path shell
 - Verify that any namespace or qualified-name access used at runtime (for example `React.X`, `module.Foo`, `pkg.Bar`) has a real value import or runtime binding, not only a type-only import or ambient type reference
 - Verify that any newly introduced runtime-sensitive dependency or packaging assumption (native modules, module-format boundaries, generated assets, required env vars, boot-time config) is reflected in validation or called out explicitly in `CONCERNS`
+- Verify that every **counterfactual claim** you wrote — in a code comment, in a test's explanatory note, or in your own status report — names a mutation you actually executed and cites its real output. A **counterfactual claim** is any statement of the form "if X were removed / restored / inverted, this check would fail / stay green". If you did not run it, delete the claim or run it now. Restore every mutation from a saved copy of the file, never with a destructive VCS command
 - If any review check fails, fix the implementation, re-run validation, and repeat this step
 
 ## Critical Constraints
@@ -64,6 +65,7 @@ If any of these cannot be determined from the spec — the requirements are too 
 - Do NOT create commits
 - Do NOT expand scope beyond the assigned task and boundary
 - Do NOT silently work around requirement or design mismatches
+- Do NOT claim that a mutation "would fail" or "would pass" without having executed it and reported its output
 - Use the exact section numbers from `requirements.md` and `design.md` in all notes and reports; do NOT invent `REQ-*` aliases
 - Do NOT stop at a mock, stub, placeholder, fake, or TODO-only implementation unless the task explicitly requires it
 - Prefer the minimal implementation that satisfies the Task Brief and tests
@@ -84,6 +86,7 @@ The parent controller parses the exact `- STATUS:` line. Do NOT rename the headi
 - REQUIREMENTS_CHECKED: <exact section numbers from requirements.md>
 - DESIGN_CHECKED: <exact section numbers from design.md>
 - RED_PHASE_OUTPUT: <test command and failing output from before implementation -- proves tests were written first>
+- MUTATIONS_EXECUTED: <for every counterfactual claim you wrote anywhere: the exact mutation, the command you ran, and its real output. Write NONE if you wrote no counterfactual claim>
 - TESTS_RUN: <test commands and final passing results>
 - CONCERNS: <optional -- describe any non-blocking concerns the reviewer should pay attention to>
 - BLOCKER: <only for BLOCKED -- describe what prevents completion>

--- a/tools/cc-sdd/templates/agents/cursor-skills/skills/kiro-impl/templates/reviewer-prompt.md
+++ b/tools/cc-sdd/templates/agents/cursor-skills/skills/kiro-impl/templates/reviewer-prompt.md
@@ -54,6 +54,11 @@ Evaluate each item. If ANY item fails, the verdict is REJECTED.
 - If the task is behavioral and RED_PHASE_OUTPUT is missing or empty → REJECTED (tests may not have been written before implementation).
 - The output should show test failures related to the task's acceptance criteria.
 
+**5.5 Executed-Mutation Evidence**
+- A **counterfactual claim** is any statement of the form "if X were removed / restored / inverted, this check would fail / stay green".
+- Read the diff and the implementer's status report. If a counterfactual claim names no executed mutation and cites no output → REJECTED.
+- **This binds you too.** Do not write such a claim in a finding unless you ran the mutation and are reporting its real output. Restore every mutation from a saved copy of the file, never with a destructive VCS command.
+
 ### Judgment Checks (read code, compare to spec)
 
 **6. Reality Check**
@@ -102,6 +107,7 @@ The parent controller parses the exact `- VERDICT:` line. Do NOT rename the head
   - Secrets grep: CLEAN | <count> matches
   - Boundary: WITHIN | <files outside boundary>
   - RED phase: VERIFIED | MISSING | N/A (non-behavioral task)
+  - Counterfactual evidence: CLEAN | <claims asserted without an executed mutation>
 - FINDINGS:
   - <numbered list of specific findings, if any>
   - <reference exact file paths, line ranges, and spec section numbers>

--- a/tools/cc-sdd/templates/agents/cursor-skills/skills/kiro-review/SKILL.md
+++ b/tools/cc-sdd/templates/agents/cursor-skills/skills/kiro-review/SKILL.md
@@ -86,6 +86,13 @@ Run these checks and use the result as primary signal.
 - For behavioral tasks, verify that the implementer status report includes `RED_PHASE_OUTPUT`.
 - Reject if RED evidence is missing, empty, or unrelated to the task's acceptance criteria.
 
+### 5.5 Executed-Mutation Evidence
+- A **counterfactual claim** is any statement of the form "if X were removed / restored / inverted, this check would fail / stay green".
+- Wherever such a claim appears — in code comments, in a test's explanatory note, in the implementer's status report, **or in your own review findings** — it must name the mutation that was actually executed and cite its real output (failing count out of the total, or the measured result).
+- Reject an implementation whose comments or status report assert a counterfactual without cited evidence.
+- **This binds you too.** A counterfactual is a measurement, not an intuition: do not write one in a finding unless you ran the mutation.
+- Restore every mutation you make from a saved copy of the file. Never use a destructive VCS command to undo one.
+
 ### 6. Runtime-Sensitive Static Checks
 - If the project already has lint or equivalent static analysis for the touched stack, run the relevant command for the task boundary.
 - Pay attention to patterns that can survive typecheck/build yet fail at runtime: type-only imports used as values, missing namespace value imports for qualified-name access, unresolved globals, and newly introduced runtime-sensitive dependencies without matching boot/runtime handling.
@@ -147,6 +154,7 @@ Escalate instead of papering over the issue when:
 | “Tests pass, so approve” | Passing tests do not prove spec compliance or boundary respect. |
 | “The extra behavior is useful” | Extra behavior outside approved scope is still drift. |
 | “The implementer said RED was done” | RED must be evidenced, not asserted. |
+| “Removing that would obviously break the check” | A counterfactual is a measurement, not an intuition. Run the mutation and cite the output, or do not write the claim. |
 | “This gap is small enough to let through” | Real gaps must be rejected or escalated. |
 
 ## Output Format
@@ -163,6 +171,7 @@ Escalate instead of papering over the issue when:
   - Boundary: WITHIN | <files outside boundary>
   - Boundary audit: CLEAN | <spillover / hidden dependency findings>
   - RED phase: VERIFIED | MISSING | N/A
+  - Counterfactual evidence: CLEAN | <claims asserted without an executed mutation>
 - FINDINGS:
   1. <specific finding with exact files/spec refs>
 - REMEDIATION: <mandatory if REJECTED>

--- a/tools/cc-sdd/templates/agents/gemini-cli-skills/skills/kiro-impl/templates/debugger-prompt.md
+++ b/tools/cc-sdd/templates/agents/gemini-cli-skills/skills/kiro-impl/templates/debugger-prompt.md
@@ -36,6 +36,8 @@ Do not collapse this investigation into guess-first patching; preserve category 
 
 ## Critical Rule
 
+**Never state what a mutation would do without executing it.** A root-cause claim of the form "restoring X would reproduce the failure" or "removing Y would make it pass" is a measurement, not an inference — run it, report the real output, and restore the file from a saved copy rather than a destructive VCS command.
+
 Use `NEXT_ACTION: STOP_FOR_HUMAN` only when the fix genuinely requires something outside the repository or the approved task plan is no longer safe to continue. If the fix is adding a dependency, changing a config file, or restructuring code inside the current task plan, prefer `NEXT_ACTION: RETRY_TASK`.
 
 ## Output
@@ -49,6 +51,7 @@ Use `NEXT_ACTION: STOP_FOR_HUMAN` only when the fix genuinely requires something
   2. <specific action with file path>
   ...
 - VERIFICATION: <command(s) to run after fix to confirm resolution>
+- MUTATIONS_EXECUTED: <every mutation you actually ran while isolating the cause, with its real output. NONE if you ran none>
 - NEXT_ACTION: RETRY_TASK | BLOCK_TASK | STOP_FOR_HUMAN
 - CONFIDENCE: HIGH | MEDIUM | LOW
 - NOTES: <any additional context the next implementer should know>

--- a/tools/cc-sdd/templates/agents/gemini-cli-skills/skills/kiro-impl/templates/implementer-prompt.md
+++ b/tools/cc-sdd/templates/agents/gemini-cli-skills/skills/kiro-impl/templates/implementer-prompt.md
@@ -57,6 +57,7 @@ If any of these cannot be determined from the spec — the requirements are too 
 - Verify the tests prove the required behavior, not just scaffolding or a happy-path shell
 - Verify that any namespace or qualified-name access used at runtime (for example `React.X`, `module.Foo`, `pkg.Bar`) has a real value import or runtime binding, not only a type-only import or ambient type reference
 - Verify that any newly introduced runtime-sensitive dependency or packaging assumption (native modules, module-format boundaries, generated assets, required env vars, boot-time config) is reflected in validation or called out explicitly in `CONCERNS`
+- Verify that every **counterfactual claim** you wrote — in a code comment, in a test's explanatory note, or in your own status report — names a mutation you actually executed and cites its real output. A **counterfactual claim** is any statement of the form "if X were removed / restored / inverted, this check would fail / stay green". If you did not run it, delete the claim or run it now. Restore every mutation from a saved copy of the file, never with a destructive VCS command
 - If any review check fails, fix the implementation, re-run validation, and repeat this step
 
 ## Critical Constraints
@@ -64,6 +65,7 @@ If any of these cannot be determined from the spec — the requirements are too 
 - Do NOT create commits
 - Do NOT expand scope beyond the assigned task and boundary
 - Do NOT silently work around requirement or design mismatches
+- Do NOT claim that a mutation "would fail" or "would pass" without having executed it and reported its output
 - Use the exact section numbers from `requirements.md` and `design.md` in all notes and reports; do NOT invent `REQ-*` aliases
 - Do NOT stop at a mock, stub, placeholder, fake, or TODO-only implementation unless the task explicitly requires it
 - Prefer the minimal implementation that satisfies the Task Brief and tests
@@ -84,6 +86,7 @@ The parent controller parses the exact `- STATUS:` line. Do NOT rename the headi
 - REQUIREMENTS_CHECKED: <exact section numbers from requirements.md>
 - DESIGN_CHECKED: <exact section numbers from design.md>
 - RED_PHASE_OUTPUT: <test command and failing output from before implementation -- proves tests were written first>
+- MUTATIONS_EXECUTED: <for every counterfactual claim you wrote anywhere: the exact mutation, the command you ran, and its real output. Write NONE if you wrote no counterfactual claim>
 - TESTS_RUN: <test commands and final passing results>
 - CONCERNS: <optional -- describe any non-blocking concerns the reviewer should pay attention to>
 - BLOCKER: <only for BLOCKED -- describe what prevents completion>

--- a/tools/cc-sdd/templates/agents/gemini-cli-skills/skills/kiro-impl/templates/reviewer-prompt.md
+++ b/tools/cc-sdd/templates/agents/gemini-cli-skills/skills/kiro-impl/templates/reviewer-prompt.md
@@ -54,6 +54,11 @@ Evaluate each item. If ANY item fails, the verdict is REJECTED.
 - If the task is behavioral and RED_PHASE_OUTPUT is missing or empty → REJECTED (tests may not have been written before implementation).
 - The output should show test failures related to the task's acceptance criteria.
 
+**5.5 Executed-Mutation Evidence**
+- A **counterfactual claim** is any statement of the form "if X were removed / restored / inverted, this check would fail / stay green".
+- Read the diff and the implementer's status report. If a counterfactual claim names no executed mutation and cites no output → REJECTED.
+- **This binds you too.** Do not write such a claim in a finding unless you ran the mutation and are reporting its real output. Restore every mutation from a saved copy of the file, never with a destructive VCS command.
+
 ### Judgment Checks (read code, compare to spec)
 
 **6. Reality Check**
@@ -102,6 +107,7 @@ The parent controller parses the exact `- VERDICT:` line. Do NOT rename the head
   - Secrets grep: CLEAN | <count> matches
   - Boundary: WITHIN | <files outside boundary>
   - RED phase: VERIFIED | MISSING | N/A (non-behavioral task)
+  - Counterfactual evidence: CLEAN | <claims asserted without an executed mutation>
 - FINDINGS:
   - <numbered list of specific findings, if any>
   - <reference exact file paths, line ranges, and spec section numbers>

--- a/tools/cc-sdd/templates/agents/gemini-cli-skills/skills/kiro-review/SKILL.md
+++ b/tools/cc-sdd/templates/agents/gemini-cli-skills/skills/kiro-review/SKILL.md
@@ -86,6 +86,13 @@ Run these checks and use the result as primary signal.
 - For behavioral tasks, verify that the implementer status report includes `RED_PHASE_OUTPUT`.
 - Reject if RED evidence is missing, empty, or unrelated to the task's acceptance criteria.
 
+### 5.5 Executed-Mutation Evidence
+- A **counterfactual claim** is any statement of the form "if X were removed / restored / inverted, this check would fail / stay green".
+- Wherever such a claim appears — in code comments, in a test's explanatory note, in the implementer's status report, **or in your own review findings** — it must name the mutation that was actually executed and cite its real output (failing count out of the total, or the measured result).
+- Reject an implementation whose comments or status report assert a counterfactual without cited evidence.
+- **This binds you too.** A counterfactual is a measurement, not an intuition: do not write one in a finding unless you ran the mutation.
+- Restore every mutation you make from a saved copy of the file. Never use a destructive VCS command to undo one.
+
 ### 6. Runtime-Sensitive Static Checks
 - If the project already has lint or equivalent static analysis for the touched stack, run the relevant command for the task boundary.
 - Pay attention to patterns that can survive typecheck/build yet fail at runtime: type-only imports used as values, missing namespace value imports for qualified-name access, unresolved globals, and newly introduced runtime-sensitive dependencies without matching boot/runtime handling.
@@ -147,6 +154,7 @@ Escalate instead of papering over the issue when:
 | “Tests pass, so approve” | Passing tests do not prove spec compliance or boundary respect. |
 | “The extra behavior is useful” | Extra behavior outside approved scope is still drift. |
 | “The implementer said RED was done” | RED must be evidenced, not asserted. |
+| “Removing that would obviously break the check” | A counterfactual is a measurement, not an intuition. Run the mutation and cite the output, or do not write the claim. |
 | “This gap is small enough to let through” | Real gaps must be rejected or escalated. |
 
 ## Output Format
@@ -163,6 +171,7 @@ Escalate instead of papering over the issue when:
   - Boundary: WITHIN | <files outside boundary>
   - Boundary audit: CLEAN | <spillover / hidden dependency findings>
   - RED phase: VERIFIED | MISSING | N/A
+  - Counterfactual evidence: CLEAN | <claims asserted without an executed mutation>
 - FINDINGS:
   1. <specific finding with exact files/spec refs>
 - REMEDIATION: <mandatory if REJECTED>

--- a/tools/cc-sdd/templates/agents/github-copilot-skills/skills/kiro-impl/templates/debugger-prompt.md
+++ b/tools/cc-sdd/templates/agents/github-copilot-skills/skills/kiro-impl/templates/debugger-prompt.md
@@ -36,6 +36,8 @@ Do not collapse this investigation into guess-first patching; preserve category 
 
 ## Critical Rule
 
+**Never state what a mutation would do without executing it.** A root-cause claim of the form "restoring X would reproduce the failure" or "removing Y would make it pass" is a measurement, not an inference — run it, report the real output, and restore the file from a saved copy rather than a destructive VCS command.
+
 Use `NEXT_ACTION: STOP_FOR_HUMAN` only when the fix genuinely requires something outside the repository or the approved task plan is no longer safe to continue. If the fix is adding a dependency, changing a config file, or restructuring code inside the current task plan, prefer `NEXT_ACTION: RETRY_TASK`.
 
 ## Output
@@ -49,6 +51,7 @@ Use `NEXT_ACTION: STOP_FOR_HUMAN` only when the fix genuinely requires something
   2. <specific action with file path>
   ...
 - VERIFICATION: <command(s) to run after fix to confirm resolution>
+- MUTATIONS_EXECUTED: <every mutation you actually ran while isolating the cause, with its real output. NONE if you ran none>
 - NEXT_ACTION: RETRY_TASK | BLOCK_TASK | STOP_FOR_HUMAN
 - CONFIDENCE: HIGH | MEDIUM | LOW
 - NOTES: <any additional context the next implementer should know>

--- a/tools/cc-sdd/templates/agents/github-copilot-skills/skills/kiro-impl/templates/implementer-prompt.md
+++ b/tools/cc-sdd/templates/agents/github-copilot-skills/skills/kiro-impl/templates/implementer-prompt.md
@@ -57,6 +57,7 @@ If any of these cannot be determined from the spec — the requirements are too 
 - Verify the tests prove the required behavior, not just scaffolding or a happy-path shell
 - Verify that any namespace or qualified-name access used at runtime (for example `React.X`, `module.Foo`, `pkg.Bar`) has a real value import or runtime binding, not only a type-only import or ambient type reference
 - Verify that any newly introduced runtime-sensitive dependency or packaging assumption (native modules, module-format boundaries, generated assets, required env vars, boot-time config) is reflected in validation or called out explicitly in `CONCERNS`
+- Verify that every **counterfactual claim** you wrote — in a code comment, in a test's explanatory note, or in your own status report — names a mutation you actually executed and cites its real output. A **counterfactual claim** is any statement of the form "if X were removed / restored / inverted, this check would fail / stay green". If you did not run it, delete the claim or run it now. Restore every mutation from a saved copy of the file, never with a destructive VCS command
 - If any review check fails, fix the implementation, re-run validation, and repeat this step
 
 ## Critical Constraints
@@ -64,6 +65,7 @@ If any of these cannot be determined from the spec — the requirements are too 
 - Do NOT create commits
 - Do NOT expand scope beyond the assigned task and boundary
 - Do NOT silently work around requirement or design mismatches
+- Do NOT claim that a mutation "would fail" or "would pass" without having executed it and reported its output
 - Use the exact section numbers from `requirements.md` and `design.md` in all notes and reports; do NOT invent `REQ-*` aliases
 - Do NOT stop at a mock, stub, placeholder, fake, or TODO-only implementation unless the task explicitly requires it
 - Prefer the minimal implementation that satisfies the Task Brief and tests
@@ -84,6 +86,7 @@ The parent controller parses the exact `- STATUS:` line. Do NOT rename the headi
 - REQUIREMENTS_CHECKED: <exact section numbers from requirements.md>
 - DESIGN_CHECKED: <exact section numbers from design.md>
 - RED_PHASE_OUTPUT: <test command and failing output from before implementation -- proves tests were written first>
+- MUTATIONS_EXECUTED: <for every counterfactual claim you wrote anywhere: the exact mutation, the command you ran, and its real output. Write NONE if you wrote no counterfactual claim>
 - TESTS_RUN: <test commands and final passing results>
 - CONCERNS: <optional -- describe any non-blocking concerns the reviewer should pay attention to>
 - BLOCKER: <only for BLOCKED -- describe what prevents completion>

--- a/tools/cc-sdd/templates/agents/github-copilot-skills/skills/kiro-impl/templates/reviewer-prompt.md
+++ b/tools/cc-sdd/templates/agents/github-copilot-skills/skills/kiro-impl/templates/reviewer-prompt.md
@@ -54,6 +54,11 @@ Evaluate each item. If ANY item fails, the verdict is REJECTED.
 - If the task is behavioral and RED_PHASE_OUTPUT is missing or empty → REJECTED (tests may not have been written before implementation).
 - The output should show test failures related to the task's acceptance criteria.
 
+**5.5 Executed-Mutation Evidence**
+- A **counterfactual claim** is any statement of the form "if X were removed / restored / inverted, this check would fail / stay green".
+- Read the diff and the implementer's status report. If a counterfactual claim names no executed mutation and cites no output → REJECTED.
+- **This binds you too.** Do not write such a claim in a finding unless you ran the mutation and are reporting its real output. Restore every mutation from a saved copy of the file, never with a destructive VCS command.
+
 ### Judgment Checks (read code, compare to spec)
 
 **6. Reality Check**
@@ -102,6 +107,7 @@ The parent controller parses the exact `- VERDICT:` line. Do NOT rename the head
   - Secrets grep: CLEAN | <count> matches
   - Boundary: WITHIN | <files outside boundary>
   - RED phase: VERIFIED | MISSING | N/A (non-behavioral task)
+  - Counterfactual evidence: CLEAN | <claims asserted without an executed mutation>
 - FINDINGS:
   - <numbered list of specific findings, if any>
   - <reference exact file paths, line ranges, and spec section numbers>

--- a/tools/cc-sdd/templates/agents/github-copilot-skills/skills/kiro-review/SKILL.md
+++ b/tools/cc-sdd/templates/agents/github-copilot-skills/skills/kiro-review/SKILL.md
@@ -86,6 +86,13 @@ Run these checks and use the result as primary signal.
 - For behavioral tasks, verify that the implementer status report includes `RED_PHASE_OUTPUT`.
 - Reject if RED evidence is missing, empty, or unrelated to the task's acceptance criteria.
 
+### 5.5 Executed-Mutation Evidence
+- A **counterfactual claim** is any statement of the form "if X were removed / restored / inverted, this check would fail / stay green".
+- Wherever such a claim appears — in code comments, in a test's explanatory note, in the implementer's status report, **or in your own review findings** — it must name the mutation that was actually executed and cite its real output (failing count out of the total, or the measured result).
+- Reject an implementation whose comments or status report assert a counterfactual without cited evidence.
+- **This binds you too.** A counterfactual is a measurement, not an intuition: do not write one in a finding unless you ran the mutation.
+- Restore every mutation you make from a saved copy of the file. Never use a destructive VCS command to undo one.
+
 ### 6. Runtime-Sensitive Static Checks
 - If the project already has lint or equivalent static analysis for the touched stack, run the relevant command for the task boundary.
 - Pay attention to patterns that can survive typecheck/build yet fail at runtime: type-only imports used as values, missing namespace value imports for qualified-name access, unresolved globals, and newly introduced runtime-sensitive dependencies without matching boot/runtime handling.
@@ -147,6 +154,7 @@ Escalate instead of papering over the issue when:
 | “Tests pass, so approve” | Passing tests do not prove spec compliance or boundary respect. |
 | “The extra behavior is useful” | Extra behavior outside approved scope is still drift. |
 | “The implementer said RED was done” | RED must be evidenced, not asserted. |
+| “Removing that would obviously break the check” | A counterfactual is a measurement, not an intuition. Run the mutation and cite the output, or do not write the claim. |
 | “This gap is small enough to let through” | Real gaps must be rejected or escalated. |
 
 ## Output Format
@@ -163,6 +171,7 @@ Escalate instead of papering over the issue when:
   - Boundary: WITHIN | <files outside boundary>
   - Boundary audit: CLEAN | <spillover / hidden dependency findings>
   - RED phase: VERIFIED | MISSING | N/A
+  - Counterfactual evidence: CLEAN | <claims asserted without an executed mutation>
 - FINDINGS:
   1. <specific finding with exact files/spec refs>
 - REMEDIATION: <mandatory if REJECTED>

--- a/tools/cc-sdd/templates/agents/opencode-skills/skills/kiro-impl/templates/debugger-prompt.md
+++ b/tools/cc-sdd/templates/agents/opencode-skills/skills/kiro-impl/templates/debugger-prompt.md
@@ -36,6 +36,8 @@ Do not collapse this investigation into guess-first patching; preserve category 
 
 ## Critical Rule
 
+**Never state what a mutation would do without executing it.** A root-cause claim of the form "restoring X would reproduce the failure" or "removing Y would make it pass" is a measurement, not an inference — run it, report the real output, and restore the file from a saved copy rather than a destructive VCS command.
+
 Use `NEXT_ACTION: STOP_FOR_HUMAN` only when the fix genuinely requires something outside the repository or the approved task plan is no longer safe to continue. If the fix is adding a dependency, changing a config file, or restructuring code inside the current task plan, prefer `NEXT_ACTION: RETRY_TASK`.
 
 ## Output
@@ -49,6 +51,7 @@ Use `NEXT_ACTION: STOP_FOR_HUMAN` only when the fix genuinely requires something
   2. <specific action with file path>
   ...
 - VERIFICATION: <command(s) to run after fix to confirm resolution>
+- MUTATIONS_EXECUTED: <every mutation you actually ran while isolating the cause, with its real output. NONE if you ran none>
 - NEXT_ACTION: RETRY_TASK | BLOCK_TASK | STOP_FOR_HUMAN
 - CONFIDENCE: HIGH | MEDIUM | LOW
 - NOTES: <any additional context the next implementer should know>

--- a/tools/cc-sdd/templates/agents/opencode-skills/skills/kiro-impl/templates/implementer-prompt.md
+++ b/tools/cc-sdd/templates/agents/opencode-skills/skills/kiro-impl/templates/implementer-prompt.md
@@ -57,6 +57,7 @@ If any of these cannot be determined from the spec — the requirements are too 
 - Verify the tests prove the required behavior, not just scaffolding or a happy-path shell
 - Verify that any namespace or qualified-name access used at runtime (for example `React.X`, `module.Foo`, `pkg.Bar`) has a real value import or runtime binding, not only a type-only import or ambient type reference
 - Verify that any newly introduced runtime-sensitive dependency or packaging assumption (native modules, module-format boundaries, generated assets, required env vars, boot-time config) is reflected in validation or called out explicitly in `CONCERNS`
+- Verify that every **counterfactual claim** you wrote — in a code comment, in a test's explanatory note, or in your own status report — names a mutation you actually executed and cites its real output. A **counterfactual claim** is any statement of the form "if X were removed / restored / inverted, this check would fail / stay green". If you did not run it, delete the claim or run it now. Restore every mutation from a saved copy of the file, never with a destructive VCS command
 - If any review check fails, fix the implementation, re-run validation, and repeat this step
 
 ## Critical Constraints
@@ -64,6 +65,7 @@ If any of these cannot be determined from the spec — the requirements are too 
 - Do NOT create commits
 - Do NOT expand scope beyond the assigned task and boundary
 - Do NOT silently work around requirement or design mismatches
+- Do NOT claim that a mutation "would fail" or "would pass" without having executed it and reported its output
 - Use the exact section numbers from `requirements.md` and `design.md` in all notes and reports; do NOT invent `REQ-*` aliases
 - Do NOT stop at a mock, stub, placeholder, fake, or TODO-only implementation unless the task explicitly requires it
 - Prefer the minimal implementation that satisfies the Task Brief and tests
@@ -84,6 +86,7 @@ The parent controller parses the exact `- STATUS:` line. Do NOT rename the headi
 - REQUIREMENTS_CHECKED: <exact section numbers from requirements.md>
 - DESIGN_CHECKED: <exact section numbers from design.md>
 - RED_PHASE_OUTPUT: <test command and failing output from before implementation -- proves tests were written first>
+- MUTATIONS_EXECUTED: <for every counterfactual claim you wrote anywhere: the exact mutation, the command you ran, and its real output. Write NONE if you wrote no counterfactual claim>
 - TESTS_RUN: <test commands and final passing results>
 - CONCERNS: <optional -- describe any non-blocking concerns the reviewer should pay attention to>
 - BLOCKER: <only for BLOCKED -- describe what prevents completion>

--- a/tools/cc-sdd/templates/agents/opencode-skills/skills/kiro-impl/templates/reviewer-prompt.md
+++ b/tools/cc-sdd/templates/agents/opencode-skills/skills/kiro-impl/templates/reviewer-prompt.md
@@ -54,6 +54,11 @@ Evaluate each item. If ANY item fails, the verdict is REJECTED.
 - If the task is behavioral and RED_PHASE_OUTPUT is missing or empty → REJECTED (tests may not have been written before implementation).
 - The output should show test failures related to the task's acceptance criteria.
 
+**5.5 Executed-Mutation Evidence**
+- A **counterfactual claim** is any statement of the form "if X were removed / restored / inverted, this check would fail / stay green".
+- Read the diff and the implementer's status report. If a counterfactual claim names no executed mutation and cites no output → REJECTED.
+- **This binds you too.** Do not write such a claim in a finding unless you ran the mutation and are reporting its real output. Restore every mutation from a saved copy of the file, never with a destructive VCS command.
+
 ### Judgment Checks (read code, compare to spec)
 
 **6. Reality Check**
@@ -102,6 +107,7 @@ The parent controller parses the exact `- VERDICT:` line. Do NOT rename the head
   - Secrets grep: CLEAN | <count> matches
   - Boundary: WITHIN | <files outside boundary>
   - RED phase: VERIFIED | MISSING | N/A (non-behavioral task)
+  - Counterfactual evidence: CLEAN | <claims asserted without an executed mutation>
 - FINDINGS:
   - <numbered list of specific findings, if any>
   - <reference exact file paths, line ranges, and spec section numbers>

--- a/tools/cc-sdd/templates/agents/opencode-skills/skills/kiro-review/SKILL.md
+++ b/tools/cc-sdd/templates/agents/opencode-skills/skills/kiro-review/SKILL.md
@@ -86,6 +86,13 @@ Run these checks and use the result as primary signal.
 - For behavioral tasks, verify that the implementer status report includes `RED_PHASE_OUTPUT`.
 - Reject if RED evidence is missing, empty, or unrelated to the task's acceptance criteria.
 
+### 5.5 Executed-Mutation Evidence
+- A **counterfactual claim** is any statement of the form "if X were removed / restored / inverted, this check would fail / stay green".
+- Wherever such a claim appears — in code comments, in a test's explanatory note, in the implementer's status report, **or in your own review findings** — it must name the mutation that was actually executed and cite its real output (failing count out of the total, or the measured result).
+- Reject an implementation whose comments or status report assert a counterfactual without cited evidence.
+- **This binds you too.** A counterfactual is a measurement, not an intuition: do not write one in a finding unless you ran the mutation.
+- Restore every mutation you make from a saved copy of the file. Never use a destructive VCS command to undo one.
+
 ### 6. Runtime-Sensitive Static Checks
 - If the project already has lint or equivalent static analysis for the touched stack, run the relevant command for the task boundary.
 - Pay attention to patterns that can survive typecheck/build yet fail at runtime: type-only imports used as values, missing namespace value imports for qualified-name access, unresolved globals, and newly introduced runtime-sensitive dependencies without matching boot/runtime handling.
@@ -147,6 +154,7 @@ Escalate instead of papering over the issue when:
 | “Tests pass, so approve” | Passing tests do not prove spec compliance or boundary respect. |
 | “The extra behavior is useful” | Extra behavior outside approved scope is still drift. |
 | “The implementer said RED was done” | RED must be evidenced, not asserted. |
+| “Removing that would obviously break the check” | A counterfactual is a measurement, not an intuition. Run the mutation and cite the output, or do not write the claim. |
 | “This gap is small enough to let through” | Real gaps must be rejected or escalated. |
 
 ## Output Format
@@ -163,6 +171,7 @@ Escalate instead of papering over the issue when:
   - Boundary: WITHIN | <files outside boundary>
   - Boundary audit: CLEAN | <spillover / hidden dependency findings>
   - RED phase: VERIFIED | MISSING | N/A
+  - Counterfactual evidence: CLEAN | <claims asserted without an executed mutation>
 - FINDINGS:
   1. <specific finding with exact files/spec refs>
 - REMEDIATION: <mandatory if REJECTED>

--- a/tools/cc-sdd/templates/agents/windsurf-skills/skills/kiro-impl/templates/debugger-prompt.md
+++ b/tools/cc-sdd/templates/agents/windsurf-skills/skills/kiro-impl/templates/debugger-prompt.md
@@ -36,6 +36,8 @@ Do not collapse this investigation into guess-first patching; preserve category 
 
 ## Critical Rule
 
+**Never state what a mutation would do without executing it.** A root-cause claim of the form "restoring X would reproduce the failure" or "removing Y would make it pass" is a measurement, not an inference — run it, report the real output, and restore the file from a saved copy rather than a destructive VCS command.
+
 Use `NEXT_ACTION: STOP_FOR_HUMAN` only when the fix genuinely requires something outside the repository or the approved task plan is no longer safe to continue. If the fix is adding a dependency, changing a config file, or restructuring code inside the current task plan, prefer `NEXT_ACTION: RETRY_TASK`.
 
 ## Output
@@ -49,6 +51,7 @@ Use `NEXT_ACTION: STOP_FOR_HUMAN` only when the fix genuinely requires something
   2. <specific action with file path>
   ...
 - VERIFICATION: <command(s) to run after fix to confirm resolution>
+- MUTATIONS_EXECUTED: <every mutation you actually ran while isolating the cause, with its real output. NONE if you ran none>
 - NEXT_ACTION: RETRY_TASK | BLOCK_TASK | STOP_FOR_HUMAN
 - CONFIDENCE: HIGH | MEDIUM | LOW
 - NOTES: <any additional context the next implementer should know>

--- a/tools/cc-sdd/templates/agents/windsurf-skills/skills/kiro-impl/templates/implementer-prompt.md
+++ b/tools/cc-sdd/templates/agents/windsurf-skills/skills/kiro-impl/templates/implementer-prompt.md
@@ -57,6 +57,7 @@ If any of these cannot be determined from the spec — the requirements are too 
 - Verify the tests prove the required behavior, not just scaffolding or a happy-path shell
 - Verify that any namespace or qualified-name access used at runtime (for example `React.X`, `module.Foo`, `pkg.Bar`) has a real value import or runtime binding, not only a type-only import or ambient type reference
 - Verify that any newly introduced runtime-sensitive dependency or packaging assumption (native modules, module-format boundaries, generated assets, required env vars, boot-time config) is reflected in validation or called out explicitly in `CONCERNS`
+- Verify that every **counterfactual claim** you wrote — in a code comment, in a test's explanatory note, or in your own status report — names a mutation you actually executed and cites its real output. A **counterfactual claim** is any statement of the form "if X were removed / restored / inverted, this check would fail / stay green". If you did not run it, delete the claim or run it now. Restore every mutation from a saved copy of the file, never with a destructive VCS command
 - If any review check fails, fix the implementation, re-run validation, and repeat this step
 
 ## Critical Constraints
@@ -64,6 +65,7 @@ If any of these cannot be determined from the spec — the requirements are too 
 - Do NOT create commits
 - Do NOT expand scope beyond the assigned task and boundary
 - Do NOT silently work around requirement or design mismatches
+- Do NOT claim that a mutation "would fail" or "would pass" without having executed it and reported its output
 - Use the exact section numbers from `requirements.md` and `design.md` in all notes and reports; do NOT invent `REQ-*` aliases
 - Do NOT stop at a mock, stub, placeholder, fake, or TODO-only implementation unless the task explicitly requires it
 - Prefer the minimal implementation that satisfies the Task Brief and tests
@@ -84,6 +86,7 @@ The parent controller parses the exact `- STATUS:` line. Do NOT rename the headi
 - REQUIREMENTS_CHECKED: <exact section numbers from requirements.md>
 - DESIGN_CHECKED: <exact section numbers from design.md>
 - RED_PHASE_OUTPUT: <test command and failing output from before implementation -- proves tests were written first>
+- MUTATIONS_EXECUTED: <for every counterfactual claim you wrote anywhere: the exact mutation, the command you ran, and its real output. Write NONE if you wrote no counterfactual claim>
 - TESTS_RUN: <test commands and final passing results>
 - CONCERNS: <optional -- describe any non-blocking concerns the reviewer should pay attention to>
 - BLOCKER: <only for BLOCKED -- describe what prevents completion>

--- a/tools/cc-sdd/templates/agents/windsurf-skills/skills/kiro-impl/templates/reviewer-prompt.md
+++ b/tools/cc-sdd/templates/agents/windsurf-skills/skills/kiro-impl/templates/reviewer-prompt.md
@@ -54,6 +54,11 @@ Evaluate each item. If ANY item fails, the verdict is REJECTED.
 - If the task is behavioral and RED_PHASE_OUTPUT is missing or empty → REJECTED (tests may not have been written before implementation).
 - The output should show test failures related to the task's acceptance criteria.
 
+**5.5 Executed-Mutation Evidence**
+- A **counterfactual claim** is any statement of the form "if X were removed / restored / inverted, this check would fail / stay green".
+- Read the diff and the implementer's status report. If a counterfactual claim names no executed mutation and cites no output → REJECTED.
+- **This binds you too.** Do not write such a claim in a finding unless you ran the mutation and are reporting its real output. Restore every mutation from a saved copy of the file, never with a destructive VCS command.
+
 ### Judgment Checks (read code, compare to spec)
 
 **6. Reality Check**
@@ -102,6 +107,7 @@ The parent controller parses the exact `- VERDICT:` line. Do NOT rename the head
   - Secrets grep: CLEAN | <count> matches
   - Boundary: WITHIN | <files outside boundary>
   - RED phase: VERIFIED | MISSING | N/A (non-behavioral task)
+  - Counterfactual evidence: CLEAN | <claims asserted without an executed mutation>
 - FINDINGS:
   - <numbered list of specific findings, if any>
   - <reference exact file paths, line ranges, and spec section numbers>

--- a/tools/cc-sdd/templates/agents/windsurf-skills/skills/kiro-review/SKILL.md
+++ b/tools/cc-sdd/templates/agents/windsurf-skills/skills/kiro-review/SKILL.md
@@ -86,6 +86,13 @@ Run these checks and use the result as primary signal.
 - For behavioral tasks, verify that the implementer status report includes `RED_PHASE_OUTPUT`.
 - Reject if RED evidence is missing, empty, or unrelated to the task's acceptance criteria.
 
+### 5.5 Executed-Mutation Evidence
+- A **counterfactual claim** is any statement of the form "if X were removed / restored / inverted, this check would fail / stay green".
+- Wherever such a claim appears — in code comments, in a test's explanatory note, in the implementer's status report, **or in your own review findings** — it must name the mutation that was actually executed and cite its real output (failing count out of the total, or the measured result).
+- Reject an implementation whose comments or status report assert a counterfactual without cited evidence.
+- **This binds you too.** A counterfactual is a measurement, not an intuition: do not write one in a finding unless you ran the mutation.
+- Restore every mutation you make from a saved copy of the file. Never use a destructive VCS command to undo one.
+
 ### 6. Runtime-Sensitive Static Checks
 - If the project already has lint or equivalent static analysis for the touched stack, run the relevant command for the task boundary.
 - Pay attention to patterns that can survive typecheck/build yet fail at runtime: type-only imports used as values, missing namespace value imports for qualified-name access, unresolved globals, and newly introduced runtime-sensitive dependencies without matching boot/runtime handling.
@@ -147,6 +154,7 @@ Escalate instead of papering over the issue when:
 | “Tests pass, so approve” | Passing tests do not prove spec compliance or boundary respect. |
 | “The extra behavior is useful” | Extra behavior outside approved scope is still drift. |
 | “The implementer said RED was done” | RED must be evidenced, not asserted. |
+| “Removing that would obviously break the check” | A counterfactual is a measurement, not an intuition. Run the mutation and cite the output, or do not write the claim. |
 | “This gap is small enough to let through” | Real gaps must be rejected or escalated. |
 
 ## Output Format
@@ -163,6 +171,7 @@ Escalate instead of papering over the issue when:
   - Boundary: WITHIN | <files outside boundary>
   - Boundary audit: CLEAN | <spillover / hidden dependency findings>
   - RED phase: VERIFIED | MISSING | N/A
+  - Counterfactual evidence: CLEAN | <claims asserted without an executed mutation>
 - FINDINGS:
   1. <specific finding with exact files/spec refs>
 - REMEDIATION: <mandatory if REJECTED>


### PR DESCRIPTION
## Problem

`kiro-impl` and `kiro-review` already refuse to approve a task on an *asserted* RED phase — it has to be evidenced. But there is a second kind of claim agents make about verification strength that nothing constrains: the **counterfactual**.

> "If this rule were removed, the check would go red."

It reads like evidence. Nothing forces the agent to have actually run the mutation. When the guess is wrong, the claim outlives it — frozen into a code comment or a review finding — and whoever reads it next mis-diagnoses the verification as stronger than it is.

We hit this three times on one project inside a few days:

| Where | Claim | Measured |
|---|---|---|
| Implementer, in a code comment | restoring a removed always-false branch would change the resize path | 48/48 unchanged — the branch never reached the body |
| **Reviewer**, in a finding | dropping the toolbar's `overflowX` would fail the test | still green — an ancestor's `overflow: hidden` was the real cause |
| Implementer, in a self-test | narrowing the range would under-report 4 records | 2, and both were false coverage claims |

All three were inferences written in the voice of measurements. Note the middle row: the reviewer — the role that exists to catch exactly this — produced one.

## Change

Apply the rule the RED phase already uses: evidence, not assertion.

- **`implementer-prompt.md`** — a Self-Review item, a Critical Constraint, and a `MUTATIONS_EXECUTED` status field (`NONE` when no counterfactual was written)
- **`reviewer-prompt.md`** — check **5.5 Executed-Mutation Evidence** and a `MECHANICAL_RESULTS` line
- **`kiro-review/SKILL.md`** — section 5.5, a Common Rationalizations row, and the matching verdict line
- **`debugger-prompt.md`** — a Critical Rule and a `MUTATIONS_EXECUTED` report field

Two deliberate details:

1. The reviewer sections say explicitly that **the rule binds the reviewer's own findings**. That was one of the three failures, and a one-sided rule would not have caught it.
2. Restoration is specified as a **write-back from a saved copy**, never a destructive VCS command — undoing a mutation must not discard the implementer's uncommitted work.

Applied to all 8 skill-based agent variants (`antigravity`, `claude-code`, `codex`, `cursor`, `gemini-cli`, `github-copilot`, `opencode`, `windsurf`) so the prompts stay in sync. 32 files, +168 / -0.

## Verification

- `npm test` in `tools/cc-sdd` — **39 files / 193 tests pass**. No installer behavior changes; templates only.
- Anchor insertion was scripted with a uniqueness assertion per anchor, so all 80 insertions (8 variants × 10) are confirmed applied at the intended position rather than silently skipped.

## Notes

Existing numbering is untouched — the new check is inserted as `5.5` so downstream references to checks 1–11 keep their meaning.

Happy to narrow this to `kiro-review` only, drop the `MUTATIONS_EXECUTED` field, or reword anything that does not match your voice for these prompts.
